### PR TITLE
round blocksync percentage down

### DIFF
--- a/react/src/components/postAuth/apps/wallet/coinWallet/coinWallet.js
+++ b/react/src/components/postAuth/apps/wallet/coinWallet/coinWallet.js
@@ -409,7 +409,7 @@ class CoinWallet extends React.Component {
                 ? this.NO_HEIGHT
                 : longestchain < blocks || longestchain === 0
                 ? 0
-                : Number(((blocks / longestchain) * 100).toFixed(2));
+                : Math.floor(((blocks / longestchain) * 10000) / 100 );
 
             walletLoadState = {
               ...walletLoadState,


### PR DESCRIPTION
Most users do not look at the message behind the percentage in the GUI.

Currently the dial shows 100% when the sync percentage exceeds 99.995 percent, leading users to think they are fully in sync.
Rounding down to two decimals will show 99.99%, until the local chain is actually in sync.

This will eliminate confusion whether a chain is in sync or not.